### PR TITLE
ci: Add Dependabot config with supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Supply-chain hardening strategy:
+# - `cooldown` delays version-update PRs until a release has aged, mitigating
+#   the window in which a hijacked/malicious version is live before the
+#   community detects it (e.g. event-stream, chalk/debug, ultralytics).
+# - cooldown does NOT apply to security updates, so CVE patches still arrive
+#   immediately.
+# - github-actions does not support cooldown (no SemVer); we lower its schedule
+#   to monthly and continue to pin Actions by SHA in workflows.
+# - patch/minor are grouped into one PR; major updates open individual PRs.
+
+version: 2
+
+updates:
+  # Rust dependencies (Cargo.toml / Cargo.lock)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    cooldown:
+      # Wait long enough for the community to detect a hijacked release.
+      # Security advisories bypass cooldown automatically.
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in workflows (.github/workflows/*.yml).
+  # `cooldown` is not supported for this ecosystem (no SemVer guarantee), so we
+  # rely on a monthly cadence plus SHA pinning to limit exposure to tag-move
+  # attacks (e.g. tj-actions/changed-files-style incidents).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Description
Introduce Dependabot configuration that automates dependency updates for Cargo and GitHub Actions while explicitly defending against supply-chain attacks (e.g. hijacked package releases such as `event-stream`, `chalk`/`debug`, `ultralytics`, `tj-actions/changed-files`).

The key idea is to **delay** version-update PRs until a release has aged enough for the community to detect malicious or compromised versions, while still allowing **security advisories to arrive immediately** so CVE response is not slowed down.

## Related Issue
N/A — proactive hardening.

## Type of Change
- [x] 🔧 Configuration change

## Implementation Details

### Key Changes
- Add `.github/dependabot.yml` with two ecosystems: `cargo` and `github-actions`.
- Cargo: enable `cooldown` (patch 3d / minor 7d / major 14d) so freshly published crate versions are not pulled in until they have been live for several days.
- GitHub Actions: `cooldown` is not supported for this ecosystem (no SemVer guarantee), so we lower its update cadence to `monthly` and continue to rely on SHA pinning + commented version tags in workflows.
- Group `minor`/`patch` updates per ecosystem to reduce PR noise; `major` updates open individual PRs for careful review.
- Use `chore(deps)` / `chore(ci)` commit prefixes to match existing project conventions.

### Supply-chain rationale
- `cooldown` deliberately does **not** apply to security updates — CVE patches bypass the wait window and PR immediately.
- Combined with existing defenses in `.github/workflows/ci.yml` (`permissions: {}`, SHA-pinned Actions, `--locked` builds, `cargo deny`), this gives layered protection: delay-on-introduction + minimized blast radius at runtime.

### TDD Process Followed
N/A — declarative configuration, no executable code paths added.

## Architecture Diagram
```mermaid
flowchart LR
    Upstream[Crate / Action<br/>new release published] -->|cooldown window| Wait{Aged enough?<br/>patch 3d / minor 7d / major 14d}
    Wait -->|no| Hold[Hold — do not open PR]
    Wait -->|yes| Group{Update type}
    Group -->|minor / patch| GroupedPR[Single grouped PR<br/>per ecosystem]
    Group -->|major| IndividualPR[Individual PR<br/>for review]
    CVE[Security advisory] -.->|bypasses cooldown| ImmediatePR[Immediate security PR]
```

## Testing

### Test Coverage
- [ ] Unit tests added/updated — N/A
- [ ] Integration tests added/updated — N/A
- [ ] End-to-end tests added/updated — N/A

### Manual Testing
```bash
# YAML syntax validated locally
python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"
# => YAML OK
```

Functional verification will occur once this is merged to `main`: GitHub will auto-detect `.github/dependabot.yml` and begin opening PRs on the configured schedule. The first run will surface any schema issues via the Insights → Dependency graph → Dependabot tab.

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] All tests pass locally with `cargo test` — unaffected (no Rust changes)
- [x] Code passes `cargo clippy -- -D warnings` — unaffected
- [x] Code is formatted with `cargo fmt` — unaffected

### Documentation
- [x] Inline comments in `dependabot.yml` explain the supply-chain rationale
- [ ] CLAUDE.md update — not required
- [ ] docs/* update — not required (no user-facing or design changes)

### Commit History
- [x] Commits follow the conventional format
- [x] Commit messages are clear and descriptive

## Additional Notes
- `cooldown` is a relatively recent Dependabot capability (GA in 2025). If the schema ever rejects, the docs at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file should be consulted.
- Tunable knobs if cooldown turns out to be too conservative (or not conservative enough): `semver-*-days` values, `open-pull-requests-limit`, and the `groups` definitions.

## Review Focus Areas
- Are the cooldown durations (3 / 7 / 14 days) appropriate for this project's risk tolerance vs. update freshness?
- Is `monthly` cadence acceptable for GitHub Actions, given SHA pinning is already in place?

---
### PR Submission Confirmation
- [x] I have tested these changes thoroughly (YAML syntax + cross-referenced official docs)
- [x] I have followed the development workflow guidelines
- [x] This PR is ready for review