### PR TITLE
chore: Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-05-17
+
+### Changed
+
+- Updated dependencies to current major versions:
+  - `thiserror` 1 → 2
+  - `toml` 0.8 → 1.1
+  - `toml_edit` 0.22 → 0.25
+  - `colored` 2 → 3
+  - `age` 0.10 → 0.11
+
+### Internal
+
+- Added a hardened CI workflow (lint, test matrix, `cargo-deny`,
+  `cargo-machete`).
+- Added Dependabot configuration with supply-chain hardening.
+
 ## [0.2.1] - 2026-05-12
 
 ### Changed
@@ -59,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nested shell prevention
 - Confirmation prompts for protected environments
 
+[0.2.2]: https://github.com/ueneid/stand/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/ueneid/stand/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/ueneid/stand/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/ueneid/stand/compare/v0.1.0...v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stand"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stand"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.88"
 authors = ["ueneid"]


### PR DESCRIPTION
## Description

Bump `stand` from **0.2.1** to **0.2.2**. This is a patch release that records dependency major upgrades and CI hardening landed since v0.2.1. There are no public CLI changes — command names, flags, and output formats are unchanged.

## Related Issue

Closes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition or modification
- [x] 🔧 Configuration change

## Implementation Details

Per SemVer, the upgraded crates (`thiserror`, `toml`, `toml_edit`, `colored`, `age`) are internal dependencies and do not affect `stand`'s public interface, so a **patch** bump (0.2.2) is the correct increment rather than minor or major. `Cargo.lock`'s `stand` entry was synced via `cargo build`.

### Key Changes

- Bump `package.version` to `0.2.2` in `Cargo.toml` and sync `Cargo.lock`.
- Add a `[0.2.2] - 2026-05-17` section to `CHANGELOG.md` documenting the dependency upgrades and CI work.
- Add the `v0.2.1...v0.2.2` compare link to the CHANGELOG footer.

### TDD Process Followed

- [ ] Tests were written before implementation
- [ ] All tests were RED before implementation
- [ ] Implementation was done to make tests GREEN
- [ ] Refactoring was performed while keeping tests GREEN

> N/A — release/version bump only; no production code changed. The full existing test suite was run to verify the dependency upgrades.

## Architecture Diagram

```mermaid
flowchart LR
    subgraph Before["v0.2.1"]
        A1["Cargo.toml<br/>version = 0.2.1"]
    end
    subgraph After["v0.2.2"]
        A2["Cargo.toml<br/>version = 0.2.2"]
        D["Dependencies bumped<br/>thiserror 2 · toml 1.1<br/>toml_edit 0.25 · colored 3<br/>age 0.11"]
        C["CHANGELOG.md<br/>[0.2.2] section"]
        L["Cargo.lock<br/>stand 0.2.2"]
    end
    Before -->|patch release| After
    A2 --- D
    A2 --- C
    A2 --- L

    style After fill:#e8f5e9
    style D fill:#fff3e0
    style C fill:#fff3e0
    style L fill:#fff3e0
```

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] End-to-end tests added/updated
- [x] Current test coverage: existing suite — 269 tests pass

### Test Scenarios Covered

1. Full existing unit + integration suite passes against the upgraded dependencies (269 passed / 0 failed).
2. `cargo clippy -- -D warnings` reports no warnings with the new crate versions.
3. `cargo fmt --check` confirms formatting is clean.

### Manual Testing

```bash
cargo build
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] All tests pass locally with `cargo test`
- [x] Code passes `cargo clippy -- -D warnings`
- [x] Code is formatted with `cargo fmt`

### Documentation

- [x] I have updated the documentation accordingly
- [x] CLAUDE.md has been updated if needed
- [x] docs/requirements.md has been updated if requirements were completed
- [x] docs/design.md has been updated if design changes were made
- [x] README.md has been updated if user-facing changes were made
- [x] Inline documentation/comments are up to date

> Only `CHANGELOG.md` needed updating; no user-facing or design changes.

### Commit History

- [x] Commits follow the conventional format (test:, feat:, refactor:, etc.)
- [x] Each commit represents a complete TDD cycle or logical unit
- [x] Commit messages are clear and descriptive
- [x] No WIP or temporary commits remain

## Breaking Changes

- [ ] This PR includes breaking changes

## Additional Notes

After merge, tag the release commit on `main` as `v0.2.2` — the CHANGELOG compare link (`v0.2.1...v0.2.2`) depends on that tag.

## Review Focus Areas

- Confirm the version increment level (patch vs. minor) is appropriate given the dependency major bumps.
- Confirm the CHANGELOG entry accurately reflects everything landed since v0.2.1.

---
### PR Submission Confirmation
- [x] I have tested these changes thoroughly
- [x] I have followed the development workflow guidelines
- [x] This PR is ready for review
